### PR TITLE
recpt1の代わりにrecisdbを使う

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ Dockerで構築する[Mirakurun] + [EDCB]構成のTV録画環境
 [KonomiTV]: https://github.com/tsukumijima/KonomiTV
 [VLC]: https://www.videolan.org/vlc/
 
+## fork元からの変更点
+
+- [KonomiTV]の導入を止める
+- [recpt1](https://github.com/stz2012/recpt1)および[libaribb25](https://github.com/tsukumijima/libaribb25)の代わりに[recisdb]を使用
+
+[recisdb]: https://github.com/kazuki0824/recisdb-rs
+
 ## 技術スタック
 
 - [Mirakurun]
-- [tsukumijima/libaribb25](https://github.com/tsukumijima/libaribb25)
-- [stz2012/recpt1](https://github.com/stz2012/recpt1)
+- [kazuki0824/recisdb-rs][recisdb]
 - [xtne6f/EDCB][EDCB]
 - [EDCB_Material_WebUI](https://github.com/EMWUI/EDCB_Material_WebUI)
 - [BonDriver_LinuxMirakc](https://github.com/matching/BonDriver_LinuxMirakc)

--- a/mirakurun/Dockerfile
+++ b/mirakurun/Dockerfile
@@ -1,26 +1,18 @@
-FROM chinachu/mirakurun
-
-# ビルド環境構築
-RUN apt update && apt install -y --no-install-recommends \
-    wget \
-    git \
-    autoconf \
-    automake \
-    && rm -rf /var/lib/apt/lists/*
-
-# デコーダーのインストール
-WORKDIR /tmp
-RUN wget https://github.com/tsukumijima/libaribb25/releases/download/v0.2.9/libaribb25_0.2.9_amd64.deb
-RUN apt install ./libaribb25_0.2.9_amd64.deb
-
-# recpt1のインストール
-WORKDIR /tmp
-RUN git clone --depth=1 https://github.com/stz2012/recpt1.git
-WORKDIR /tmp/recpt1/recpt1
-RUN ./autogen.sh
-RUN ./configure
-RUN make -j "$(nproc)"
-RUN make install
-RUN make clean
-
+# recisdbのダウンロード
+# MirakurunのDockerイメージ内で行う場合、wgetコマンドを追加でインストールしなければならない。これは最終イメージサイズの増加に繋がる。
+# そこでMulti-stage buildを採用し、MirakurunのDockerイメージにはダウンロード済のrecisdb.debのみをコピーすることで最終イメージサイズを削減する。
+# Note: buildpack-deps:bookworm-curlは、wgetやcurlなどが予め同梱されている最小サイズのDockerイメージ。
+#       これを使うことにより、事前ビルド時にダウンロードしなければならないイメージサイズも最小化し、
+#       かつ、動的なapt-getコマンド実行を避けることでDockerイメージのビルド時間を高速化する。
+FROM buildpack-deps:bookworm-curl AS download-recisdb
 WORKDIR /app
+RUN wget https://github.com/kazuki0824/recisdb-rs/releases/download/1.2.3/recisdb_1.2.3-1_arm64.deb -O ./recisdb.deb
+
+# MirakurunのDockerイメージを起動
+# digestでDockerイメージのバージョンを固定: chinachu/mirakurun:4.0.0-beta.18
+FROM chinachu/mirakurun@sha256:0cfb0399862832ceea6db74e8397275d514dcae25e1a467be373a2ae0875deb9
+WORKDIR /app
+# recisdb.debをMirakurunのDockerイメージ内へコピー
+COPY --from=download-recisdb /app/recisdb.deb /tmp
+# recisdbのインストール
+RUN apt-get install -y /tmp/recisdb.deb && rm /tmp/recisdb.deb

--- a/mirakurun/conf/tuners.yml.example
+++ b/mirakurun/conf/tuners.yml.example
@@ -4,26 +4,22 @@
   - name: 'PLEX PX-W3U4 (Terrestrial) #1'
     types:
       - GR
-    command: recpt1 --device /dev/px4video2 <channel> - -
-    decoder: arib-b25-stream-test
+    command: recisdb tune --device /dev/px4video2 --channel <channel> -
     isDisabled: false
   - name: 'PLEX PX-W3U4 (Terrestrial) #2'
     types:
       - GR
-    command: recpt1 --device /dev/px4video3 <channel> - -
-    decoder: arib-b25-stream-test
+    command: recisdb tune --device /dev/px4video3 --channel <channel> -
     isDisabled: false
   - name: 'PLEX PX-W3U4 (Satellite) #1'
     types:
       - BS
       - CS
-    command: recpt1 --device /dev/px4video0 <channel> - -
-    decoder: arib-b25-stream-test
+    command: recisdb tune --device /dev/px4video0 --channel <channel> -
     isDisabled: false
   - name: 'PLEX PX-W3U4 (Satellite) #2'
     types:
       - BS
       - CS
-    command: recpt1 --device /dev/px4video1 <channel> - -
-    decoder: arib-b25-stream-test
+    command: recisdb tune --device /dev/px4video1 --channel <channel> -
     isDisabled: false


### PR DESCRIPTION
[recpt1](https://github.com/stz2012/recpt1)はもはや古い！ナウでヤングなのは[recisdb](https://github.com/kazuki0824/recisdb-rs)。

参考：[【2023年10月】Ubuntu \+ Mirakurun \+ EDCB\-Wine \+ KonomiTV \(px4\_drv \+ recisdb \+ ISDBScanner\) でパパッと Linux 録画鯖構築の手引き \| つくみ島だより](https://blog.tsukumijima.net/article/ubuntu-edcb-konomitv-dtv-server/)