### PR TITLE
Dockerのlogging driverにjournaldを使う

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Dockerで構築する[Mirakurun] + [EDCB]構成のTV録画環境
 
 - [KonomiTV]の導入を止める
 - [recpt1](https://github.com/stz2012/recpt1)および[libaribb25](https://github.com/tsukumijima/libaribb25)の代わりに[recisdb]を使用
+- Dockerのログを[`json-file`](https://docs.docker.com/engine/logging/drivers/json-file/)の代わりに[`journald`](https://docs.docker.com/engine/logging/drivers/journald/)を使って書き込む
 
 [recisdb]: https://github.com/kazuki0824/recisdb-rs
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,10 +23,13 @@ services:
       - /dev/px4video3:/dev/px4video3
     restart: always
     logging:
-      driver: json-file
+      # ログはjournaldで記録する
+      # デフォルトのjson-fileはログが /var/lib/docker/containers/*/*-json.log ファイルに記録される一方、
+      # journaldの場合はログが /var/log/ 以下に集約されるため、
+      # log2ramやzram-configのような書き込み頻度を抑えてSDカードの寿命を伸ばすソフトウェアが使用しやすい。
+      driver: journald
       options:
-        max-file: "1"
-        max-size: 10m
+        tag: mirakurun
 
   edcb_chscan:
     image: edcb


### PR DESCRIPTION
デフォルトの[`json-file`](https://docs.docker.com/engine/logging/drivers/json-file/)はログが`/var/lib/docker/containers/*/*-json.log`ファイルに記録されるが、 [`journald`](https://docs.docker.com/engine/logging/drivers/journald/)の場合はログが`/var/log/`以下に集約される。このため、[log2ram](https://github.com/azlux/log2ram)や[zram-config](https://github.com/ecdye/zram-config)のような「書き込み頻度を抑えてSDカードの寿命を伸ばす」ソフトウェアが使用しやすい。

参考：[Dockerのlogging driver: それぞれの特徴と使いどころ\(json\-file, syslog, journald, fluentd\) \#Fluentd \- Qiita](https://qiita.com/tkit/items/9eb2a952b986b35956cd)